### PR TITLE
Fix script tag order in head for bootstrap

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,8 +9,8 @@
 	<!-- Bootstrap/Bootswatch -->
 	<link rel="stylesheet" href="bootstrap/dist/css/bootstrap.min.css">
 	<link rel="stylesheet" href="bootswatch/cosmo/bootstrap.min.css">
+	<script src="jquery/dist/jquery.min.js"></script>
 	<script src="bootstrap/dist/js/bootstrap.min.js"></script>
-	<script src="bootstrap/jquery/dist/jquery.min.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
script tag for jquery was after script tag for bootstrap.min.js which is dependent on jquery